### PR TITLE
Issues #4 and #5: data and salt arguments required  error fixed. 

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -19,6 +19,7 @@ mongoose.connect('mongodb://localhost:27017/rbac', { useNewUrlParser: true }).th
 });
 
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
 
 app.use(async (req, res, next) => {
   if (req.headers["x-access-token"]) {


### PR DESCRIPTION
Getting **data and salt arguments required  error**  when calling sign-up API. This is due to not validating request boyd parameters for JSON. Fixed this issue by calling JSON validator middleware function.